### PR TITLE
Restructure `dist` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-dist
+dist/js

--- a/dist/index.html
+++ b/dist/index.html
@@ -7,9 +7,9 @@
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0">
 
     <!-- load webcomponents -->
-    <script type="module" src="thumbs.js"></script>
-    <script type="module" src="thumbs-with-attribute.js"></script>
-    <script type="module" src="thumbs-with-slots.js"></script>
+    <script type="module" src="js/thumbs.js"></script>
+    <script type="module" src="js/thumbs-with-attribute.js"></script>
+    <script type="module" src="js/thumbs-with-slots.js"></script>
   </head>
   <body>
     <h1>Webcomponents</h1>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
       "lib": ["ES2023", "dom"],
       "module": "ESNext",
       "target": "ES2022",
-      "outDir": "./dist",
+      "outDir": "./dist/js",
       "rootDir": "./src",
       "moduleResolution": "node"
     },


### PR DESCRIPTION
Because `dist` was in `.gitignore` any change to `index.html` required a force add. This transpiles the TypeScript to `dist/js`, allowing making changes on the html file(s) without required force adding to Git.