### PR TITLE
Use unnamed slots for `component-preview`

### DIFF
--- a/src/component-preview.ts
+++ b/src/component-preview.ts
@@ -56,7 +56,9 @@ template.innerHTML = `
     </div>
     <div>
         <h3>Result</h3>
-        <div id="preview"></div>
+        <div id="preview">
+            <slot></slot>
+        </div>
     </div>
 </div>
 <div id="link" class="hidden"><a href="#">Source code</a></div>
@@ -73,8 +75,15 @@ window.customElements.define('component-preview', class ComponentPreview extends
         this.attachShadow({ mode: 'open'})
             .append(template.content.cloneNode(true));
 
-        this.shadowRoot.querySelector('#preview').innerHTML = html;
-        this.shadowRoot.querySelector('#code').innerHTML = this.escape(html.trim());
+        this.shadowRoot.querySelector('slot').addEventListener('slotchange', () => {
+            const html = (this.shadowRoot.querySelector('slot') as HTMLSlotElement).assignedNodes().reduce(
+                (carry, current: Element | Text) => current instanceof Element
+                    ? `${carry} ${current.outerHTML}`
+                    : `${carry} ${current.textContent}`,
+                ''
+            );
+            this.shadowRoot.querySelector('#code').innerHTML = this.escape(html.trim());
+        });
 
         if (url) {
             this.shadowRoot.querySelector('#link > a').setAttribute('href', url);


### PR DESCRIPTION
Based of the information on https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots#sect2

All the top level child nodes that don't specify a slot attribute will become available as an unnamed slot. We can use this instead of reading `innerHTML` as this had some unwanted side effects; Reading the `innerHTML` and inserting it again made that the webcomponents within the `component-preview` element were created and attached twice.